### PR TITLE
fix/syntax-error-in-logging

### DIFF
--- a/pydantic_ssm_settings/source.py
+++ b/pydantic_ssm_settings/source.py
@@ -48,7 +48,7 @@ class AwsSsmSettingsSource:
         if not secrets_path.is_absolute():
             raise ValueError("SSM prefix must be absolute path")
 
-        logger.debug(f"Building SSM settings with prefix of {secrets_path=}")
+        logger.debug(f"Building SSM settings with prefix of {secrets_path}")
 
         output = {}
         try:


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- fixing syntax error 

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- fixed line `logger.debug(f"Building SSM settings with prefix of {secrets_path=}")`
