### PR TITLE
fix: syntax-error-in-logging

### DIFF
--- a/pydantic_ssm_settings/source.py
+++ b/pydantic_ssm_settings/source.py
@@ -48,7 +48,7 @@ class AwsSsmSettingsSource:
         if not secrets_path.is_absolute():
             raise ValueError("SSM prefix must be absolute path")
 
-        logger.debug(f"Building SSM settings with prefix of {secrets_path=}")
+        logger.debug(f"Building SSM settings with prefix of {secrets_path}")
 
         output = {}
         try:


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- fixed syntax error in `pydantic_ssm_settings/source.py`

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- removed redundant character from line `logger.debug(f"Building SSM settings with prefix of {secrets_path}")`

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- run any example

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- n/a
